### PR TITLE
Add github action to deploy to deta (CI/CD)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,35 @@
+# Inspired by https://github.com/BogDAAAMN/deta-deploy-action
+name: "Deploy to Deta"
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DETA_NAME: "note-bank"
+  DETA_PROJECT: "default"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Install Deta CLI as per docs
+      # https://docs.deta.sh/docs/cli/install
+      - name: Install Deta CLI
+        shell: bash
+        run: |
+          curl -fsSL https://get.deta.dev/cli.sh | sh
+
+      # Checkout the repo
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      # Using the access token, deploy the project to Deta
+      # https://docs.deta.sh/docs/cli/commands#deta-deploy
+      - name: Deploy to Deta
+        shell: bash
+        run: |
+          export DETA_ACCESS_TOKEN=${{ secrets.DETA_ACCESS_TOKEN }}
+          ~/.deta/bin/deta deploy


### PR DESCRIPTION
This adds an action to the repo that will re-deploy the app every time a commit is pushed to the `main` branch. It is a script that GitHub runs.

To make it work make sure that the `DETA_NAME` and `DETA_PROJECT` on line 10-11 is correct. It probably is.

Also you have to add a secret `DETA_ACCESS_TOKEN`.

1. Create an access token:
    - Go to https://web.deta.sh/home/:your_username
    - Click "Settings"
    - Click "Create Token" and copy the "Access Token" field. **NOTE that you should keep this secret. Do not write it down in a file that you can accidentally commit**
2. Add the access token to GitHub as a "Repository Secret". It will only be accessible by the GitHub action (no humans involved):
    - Follow [this tutorial](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
    - The secret name should be `DETA_ACCESS_TOKEN`